### PR TITLE
Add statistics about connections and usage

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "envoy_postgres_extension")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_SHA = "6d816ad9af0527e63ac58d0ffe7eac29bfe56d62"
+ENVOY_SHA = "bb7ceff4c3c5bd4555dff28b6e56d27f2f8be0a7"
 
 http_archive(
     name = "envoy",

--- a/source/extensions/filters/network/postgresql_proxy/BUILD
+++ b/source/extensions/filters/network/postgresql_proxy/BUILD
@@ -15,14 +15,24 @@ api_proto_package()
 
 envoy_cc_library(
     name = "filter",
-    srcs = ["postgresql_filter.cc"],
-    hdrs = ["postgresql_filter.h"],
+    srcs = [
+        "postgresql_filter.cc",
+        "postgresql_utils.cc",
+        "postgresql_decoder.cc"
+    ],
+    hdrs = [
+        "postgresql_filter.h",
+        "postgresql_utils.h",
+        "postgresql_decoder.h",
+        "postgresql_session.h"
+    ],
     repository = "@envoy",
     deps = [
         "@envoy//include/envoy/network:filter_interface",
         "@envoy//include/envoy/server:filter_config_interface",
         "@envoy//include/envoy/stats:stats_interface",
         "@envoy//include/envoy/stats:stats_macros",
+        "@envoy//source/common/buffer:buffer_lib",
         "@envoy//source/common/network:filter_lib",
     ],
 )

--- a/source/extensions/filters/network/postgresql_proxy/postgresql_decoder.cc
+++ b/source/extensions/filters/network/postgresql_proxy/postgresql_decoder.cc
@@ -1,0 +1,162 @@
+#include "extensions/filters/network/postgresql_proxy/postgresql_decoder.h"
+#include "extensions/filters/network/postgresql_proxy/postgresql_utils.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace PostgreSQLProxy {
+
+void DecoderImpl::parseMessage(Buffer::Instance& data) {
+  ENVOY_LOG(trace, "postgresql_proxy: parsing message, len {}", data.length());
+
+  std::string cmd;
+  std::string message;
+  uint32_t length;
+
+  setMessageLength(data.length());
+
+  BufferHelper::readStringBySize(data, 1, cmd);
+  setCommand(cmd);
+
+  BufferHelper::readUint32(data, length); // just drain the four bytes
+
+  BufferHelper::readStringBySize(data, data.length(), message);
+  setMessage(message);
+
+  ENVOY_LOG(trace, "postgresql_proxy: msg parsed");
+}
+
+void DecoderImpl::decode(Buffer::Instance& data) {
+  ENVOY_LOG(trace, "postgresql_proxy: decoding {} bytes", data.length());
+
+  parseMessage(data);
+
+  if (isBackend()) {
+    decodeBackend();
+  } else {
+    decodeFrontend();
+  }
+
+  ENVOY_LOG(trace, "postgresql_proxy: {} bytes remaining in buffer", data.length());
+}
+
+void DecoderImpl::decodeBackend() {
+  ENVOY_LOG(debug, "(Backend) command = {}", getCommand());
+  ENVOY_LOG(debug, "(Backend) length = {}", getMessageLength());
+  ENVOY_LOG(debug, "(Backend) message = {}", getMessage());
+
+  // Decode the backend commands
+  switch (getCommand()[0])
+  {
+  case 'C': // CommandComplete
+  case '2': // BindComplete
+  case 'S': // ParameterStatus
+    decodeBackendStatements();
+    break;
+
+  case '1': // ParseComplete
+    callbacks_.incStatements();
+    callbacks_.incStatementsOther();
+    break;
+
+  case 'T': // RowDescription
+    decodeBackendRowDescription();
+    break;
+
+  case 'R': // AuthenticationOk
+    callbacks_.incSessions();
+    break;
+
+  case 'E': // ErrorResponse
+    decodeBackendErrorResponse();
+    break;
+
+  case 'N': // NoticeResponse
+    decodeBackendNoticeResponse();
+    break;
+  }
+}
+
+void DecoderImpl::decodeBackendStatements() {
+  callbacks_.incStatements();
+  if (getMessage().find("BEGIN") != std::string::npos) {
+    callbacks_.incStatementsOther();
+    session_.setInTransaction(true);
+  } else if (getMessage().find("START TRANSACTION") != std::string::npos) {
+    callbacks_.incStatementsOther();
+    session_.setInTransaction(true);
+  } else if (getMessage().find("ROLLBACK") != std::string::npos) {
+    callbacks_.incStatementsOther();
+    session_.setInTransaction(false);
+    callbacks_.incTransactionsRollback();
+  } else if (getMessage().find("COMMIT") != std::string::npos) {
+    callbacks_.incStatementsOther();
+    session_.setInTransaction(false);
+    callbacks_.incTransactionsCommit();
+  } else if (getMessage().find("INSERT") != std::string::npos) {
+    callbacks_.incStatementsInsert();
+    callbacks_.incTransactionsCommit();
+  } else if (getMessage().find("UPDATE") != std::string::npos) {
+    callbacks_.incStatementsUpdate();
+    callbacks_.incTransactionsCommit();
+  } else if (getMessage().find("DELETE") != std::string::npos) {
+    callbacks_.incStatementsDelete();
+    callbacks_.incTransactionsCommit();
+  } else {
+    callbacks_.incStatementsOther();
+    callbacks_.incTransactionsCommit();
+  }
+}
+
+void DecoderImpl::decodeBackendErrorResponse() {
+  if (getMessage().find("VERROR") != std::string::npos) {
+    callbacks_.incErrors();
+  }
+}
+
+void DecoderImpl::decodeBackendNoticeResponse() {
+  if (getMessage().find("VWARNING") != std::string::npos) {
+    callbacks_.incWarnings();
+  }
+}
+
+void DecoderImpl::decodeBackendRowDescription() {
+  callbacks_.incStatements();
+  callbacks_.incStatementsSelect();
+  callbacks_.incTransactionsCommit();
+}
+
+void DecoderImpl::decodeFrontend() {
+  ENVOY_LOG(debug, "(Frontend) command = {}", getCommand());
+  ENVOY_LOG(debug, "(Frontend) length = {}", getMessageLength());
+  ENVOY_LOG(debug, "(Frontend) message = {}", getMessage());
+
+  switch (getCommand()[0])
+  {
+  case 'Q':
+    session_.setProtocolType(PostgreSQLSession::ProtocolType::Simple);
+    break;
+
+  case 'P':
+  case 'B':
+    session_.setProtocolType(PostgreSQLSession::ProtocolType::Extended);
+    break;
+  }
+}
+
+bool DecoderImpl::isBackend() {
+  return (session_.getProtocolDirection() == PostgreSQLSession::ProtocolDirection::Backend);
+}
+
+bool DecoderImpl::isFrontend() {
+  return (session_.getProtocolDirection() == PostgreSQLSession::ProtocolDirection::Frontend);
+}
+
+void DecoderImpl::onData(Buffer::Instance& data) {
+  decode(data);
+}
+
+} // namespace PostgreSQLProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/postgresql_proxy/postgresql_decoder.h
+++ b/source/extensions/filters/network/postgresql_proxy/postgresql_decoder.h
@@ -1,0 +1,92 @@
+#pragma once
+#include <cstdint>
+
+#include "envoy/common/platform.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/logger.h"
+
+#include "extensions/filters/network/postgresql_proxy/postgresql_session.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace PostgreSQLProxy {
+
+/**
+ * General callbacks for dispatching decoded PostgreSQL messages to a sink.
+ */
+class DecoderCallbacks {
+public:
+  virtual ~DecoderCallbacks() = default;
+
+  virtual void incErrors() PURE;
+  virtual void incSessions() PURE;
+  virtual void incStatements() PURE;
+  virtual void incStatementsDelete() PURE;
+  virtual void incStatementsInsert() PURE;
+  virtual void incStatementsOther() PURE;
+  virtual void incStatementsSelect() PURE;
+  virtual void incStatementsUpdate() PURE;
+  virtual void incTransactions() PURE;
+  virtual void incTransactionsCommit() PURE;
+  virtual void incTransactionsRollback() PURE;
+  virtual void incWarnings() PURE;
+};
+
+/**
+ * PostgreSQL message decoder.
+ */
+class Decoder {
+public:
+  virtual ~Decoder() = default;
+
+  virtual void onData(Buffer::Instance& data) PURE;
+  virtual PostgreSQLSession& getSession() PURE;
+};
+
+using DecoderPtr = std::unique_ptr<Decoder>;
+
+class DecoderImpl : public Decoder, Logger::Loggable<Logger::Id::filter> {
+public:
+  DecoderImpl(DecoderCallbacks& callbacks) : callbacks_(callbacks) {}
+
+  // PostgreSQLProxy::Decoder
+  void onData(Buffer::Instance& data) override;
+  PostgreSQLSession& getSession() override { return session_; }
+
+  // Temp stuff for testing purposes
+  void setCommand(std::string command) { command_ = command; }
+  std::string getCommand() { return command_; }
+
+  void setMessage(std::string message) { message_ = message; }
+  std::string getMessage() { return message_; }
+  
+  void setMessageLength(uint32_t message_len) { message_len_ = message_len; }
+  uint32_t getMessageLength() { return message_len_; }
+private:
+  void parseMessage(Buffer::Instance& data);
+  void decode(Buffer::Instance& data);
+  void decodeBackend();
+  void decodeBackendStatements();
+  void decodeBackendErrorResponse();
+  void decodeBackendNoticeResponse();
+  void decodeBackendRowDescription();
+
+  void decodeFrontend();
+  bool isFrontend();
+  bool isBackend();
+
+  DecoderCallbacks& callbacks_;
+  PostgreSQLSession session_;
+
+  std::string command_;
+  std::string message_;
+  uint32_t message_len_;
+  bool in_transaction_{false};
+};
+
+} // namespace PostgreSQLProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/postgresql_proxy/postgresql_filter.cc
+++ b/source/extensions/filters/network/postgresql_proxy/postgresql_filter.cc
@@ -1,4 +1,6 @@
+#include "extensions/filters/network/postgresql_proxy/postgresql_decoder.h"
 #include "extensions/filters/network/postgresql_proxy/postgresql_filter.h"
+#include "extensions/filters/network/postgresql_proxy/postgresql_utils.h"
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/network/connection.h"
@@ -11,24 +13,105 @@ namespace PostgreSQLProxy {
 PostgreSQLFilterConfig::PostgreSQLFilterConfig(const std::string& stat_prefix, Stats::Scope& scope)
     : stat_prefix_{stat_prefix}, scope_{scope}, stats_{generateStats(stat_prefix, scope)} {}
 
-PostgreSQLFilter::PostgreSQLFilter(PostgreSQLFilterConfigSharedPtr config) : config_{config} {}
+PostgreSQLFilter::PostgreSQLFilter(PostgreSQLFilterConfigSharedPtr config) : config_{config} {
+  if (!decoder_) {
+    decoder_ = createDecoder(*this);
+  }
+}
 
 // Network::ReadFilter
 Network::FilterStatus PostgreSQLFilter::onData(Buffer::Instance& data, bool) {
   ENVOY_CONN_LOG(trace, "echo: got {} bytes", read_callbacks_->connection(), data.length());
+
+  // Frontend Buffer
+  frontend_buffer_.add(data);
+  decoder_->getSession().setProtocolDirection(PostgreSQLSession::ProtocolDirection::Frontend);
+  doDecode(frontend_buffer_);
+
   return Network::FilterStatus::Continue;
 }
-Network::FilterStatus PostgreSQLFilter::onNewConnection() {
-  config_->stats_.sessions_.inc();
-  return Network::FilterStatus::Continue;
-}
+
+Network::FilterStatus PostgreSQLFilter::onNewConnection() { return Network::FilterStatus::Continue; }
+
 void PostgreSQLFilter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
   read_callbacks_ = &callbacks;
 }
 
 // Network::WriteFilter
-Network::FilterStatus PostgreSQLFilter::onWrite(Buffer::Instance&, bool) {
+Network::FilterStatus PostgreSQLFilter::onWrite(Buffer::Instance& data, bool) {
+
+  // Backend Buffer
+  backend_buffer_.add(data);
+  decoder_->getSession().setProtocolDirection(PostgreSQLSession::ProtocolDirection::Backend);
+  doDecode(backend_buffer_);
+
   return Network::FilterStatus::Continue;
+}
+
+DecoderPtr PostgreSQLFilter::createDecoder(DecoderCallbacks& callbacks) {
+  return std::make_unique<DecoderImpl>(callbacks);
+}
+
+void PostgreSQLFilter::incErrors() { config_->stats_.errors_.inc(); }
+
+void PostgreSQLFilter::incSessions() { config_->stats_.sessions_.inc(); }
+
+void PostgreSQLFilter::incStatements() { config_->stats_.statements_.inc(); }
+
+void PostgreSQLFilter::incStatementsDelete() {
+  config_->stats_.statements_delete_.inc();
+  incTransactions();
+}
+
+void PostgreSQLFilter::incStatementsInsert() {
+  config_->stats_.statements_insert_.inc();
+  incTransactions();
+}
+
+void PostgreSQLFilter::incStatementsOther() {
+  config_->stats_.statements_other_.inc();
+  incTransactions();
+}
+
+void PostgreSQLFilter::incStatementsSelect() {
+  config_->stats_.statements_select_.inc();
+  incTransactions();
+}
+
+void PostgreSQLFilter::incStatementsUpdate() {
+  config_->stats_.statements_update_.inc();
+  incTransactions();
+}
+
+void PostgreSQLFilter::incTransactions() {
+  if (!decoder_->getSession().inTransaction()) {
+    config_->stats_.transactions_.inc();
+  }
+}
+
+void PostgreSQLFilter::incTransactionsCommit() {
+  if (!decoder_->getSession().inTransaction()) {
+    config_->stats_.transactions_commit_.inc();
+  }
+}
+
+void PostgreSQLFilter::incTransactionsRollback() {
+  if (!decoder_->getSession().inTransaction()) {
+    config_->stats_.transactions_rollback_.inc();
+  }
+}
+
+void PostgreSQLFilter::incWarnings() { config_->stats_.warnings_.inc(); }
+
+void PostgreSQLFilter::doDecode(Buffer::Instance& data) {
+  try {
+    decoder_->onData(data);
+  } catch (EnvoyException& e) {
+    ENVOY_LOG(info, "postgresql_proxy: decoding error: {}", e.what());
+    frontend_buffer_.drain(frontend_buffer_.length());
+    backend_buffer_.drain(backend_buffer_.length());
+  }
+
 }
 
 } // namespace PostgreSQLProxy

--- a/source/extensions/filters/network/postgresql_proxy/postgresql_filter.h
+++ b/source/extensions/filters/network/postgresql_proxy/postgresql_filter.h
@@ -5,7 +5,10 @@
 #include "envoy/stats/stats.h"
 #include "envoy/stats/stats_macros.h"
 
+#include "common/buffer/buffer_impl.h"
 #include "common/common/logger.h"
+
+#include "extensions/filters/network/postgresql_proxy/postgresql_decoder.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -15,8 +18,19 @@ namespace PostgreSQLProxy {
 /**
  * All PostgreSQL proxy stats. @see stats_macros.h
  */
-#define ALL_POSTGRESQL_PROXY_STATS(COUNTER)                                                        \
-  COUNTER(sessions)
+#define ALL_POSTGRESQL_PROXY_STATS(COUNTER)   \
+  COUNTER(sessions)                           \
+  COUNTER(errors)                             \
+  COUNTER(statements)                         \
+  COUNTER(statements_insert)                  \
+  COUNTER(statements_delete)                  \
+  COUNTER(statements_update)                  \
+  COUNTER(statements_select)                  \
+  COUNTER(statements_other)                   \
+  COUNTER(transactions)                       \
+  COUNTER(transactions_commit)                \
+  COUNTER(transactions_rollback)              \
+  COUNTER(warnings)
 
 /**
  * Struct definition for all PostgreSQL proxy stats. @see stats_macros.h
@@ -44,7 +58,7 @@ private:
 
 using PostgreSQLFilterConfigSharedPtr = std::shared_ptr<PostgreSQLFilterConfig>;
 
-class PostgreSQLFilter : public Network::Filter, Logger::Loggable<Logger::Id::filter> {
+class PostgreSQLFilter : public Network::Filter, DecoderCallbacks, Logger::Loggable<Logger::Id::filter> {
 public:
   PostgreSQLFilter(PostgreSQLFilterConfigSharedPtr config);
   ~PostgreSQLFilter() override = default;
@@ -57,9 +71,28 @@ public:
   // Network::WriteFilter
   Network::FilterStatus onWrite(Buffer::Instance& data, bool end_stream) override;
 
+  // PostgreSQLProxy::DecoderCallback
+  void incErrors() override;
+  void incSessions() override;
+  void incStatements() override;
+  void incStatementsDelete() override;
+  void incStatementsInsert() override;
+  void incStatementsOther() override;
+  void incStatementsSelect() override;
+  void incStatementsUpdate() override;
+  void incTransactions() override;
+  void incTransactionsCommit() override;
+  void incTransactionsRollback() override;
+  void incWarnings() override;
+
+  void doDecode(Buffer::Instance& data);
+  DecoderPtr createDecoder(DecoderCallbacks& callbacks);
 private:
   Network::ReadFilterCallbacks* read_callbacks_{};
   PostgreSQLFilterConfigSharedPtr config_;
+  Buffer::OwnedImpl frontend_buffer_;
+  Buffer::OwnedImpl backend_buffer_;
+  std::unique_ptr<Decoder> decoder_;
 };
 
 } // namespace PostgreSQLProxy

--- a/source/extensions/filters/network/postgresql_proxy/postgresql_session.h
+++ b/source/extensions/filters/network/postgresql_proxy/postgresql_session.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <cstdint>
+
+#include "common/common/logger.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace PostgreSQLProxy {
+
+class PostgreSQLSession : Logger::Loggable<Logger::Id::filter> {
+public:
+  enum class ProtocolDirection {
+    Frontend,
+    Backend,
+    Both
+  };
+
+  enum class ProtocolType {
+    Simple,
+    Extended
+  };
+
+  void setProtocolDirection(PostgreSQLSession::ProtocolDirection protocol_direction) { protocol_direction_ = protocol_direction; }
+  PostgreSQLSession::ProtocolDirection getProtocolDirection() { return protocol_direction_; }
+
+  void setProtocolType(PostgreSQLSession::ProtocolType protocol_type) { protocol_type_ = protocol_type; }
+  PostgreSQLSession::ProtocolType getProtocolType() { return protocol_type_; }
+
+  bool inTransaction() { return in_transaction_; };
+  void setInTransaction(bool in_transaction) { in_transaction_ = in_transaction; };
+
+private:
+  PostgreSQLSession::ProtocolDirection protocol_direction_;
+  PostgreSQLSession::ProtocolType protocol_type_;
+  bool in_transaction_{false};
+};
+
+} // namespace PostgreSQLProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/postgresql_proxy/postgresql_utils.cc
+++ b/source/extensions/filters/network/postgresql_proxy/postgresql_utils.cc
@@ -1,0 +1,91 @@
+#include "extensions/filters/network/postgresql_proxy/postgresql_utils.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace PostgreSQLProxy {
+
+bool BufferHelper::endOfBuffer(Buffer::Instance& buffer) {
+  return buffer.length() == 0;
+}
+
+int BufferHelper::readUint8(Buffer::Instance& buffer, uint8_t& val) {
+  try {
+    val = buffer.peekLEInt<uint8_t>(0);
+    buffer.drain(sizeof(uint8_t));
+    return POSTGRESQL_SUCCESS;
+  } catch (EnvoyException& e) {
+    // buffer underflow
+    return POSTGRESQL_FAILURE;
+  }
+}
+
+int BufferHelper::readUint16(Buffer::Instance& buffer, uint16_t& val) {
+  try {
+    val = buffer.peekLEInt<uint16_t>(0);
+    buffer.drain(sizeof(uint16_t));
+    return POSTGRESQL_SUCCESS;
+  } catch (EnvoyException& e) {
+    // buffer underflow
+    return POSTGRESQL_FAILURE;
+  }
+}
+
+int BufferHelper::readUint32(Buffer::Instance& buffer, uint32_t& val) {
+  try {
+    val = buffer.peekLEInt<uint32_t>(0);
+    buffer.drain(sizeof(uint32_t));
+    return POSTGRESQL_SUCCESS;
+  } catch (EnvoyException& e) {
+    // buffer underflow
+    return POSTGRESQL_FAILURE;
+  }
+}
+
+int BufferHelper::readBytes(Buffer::Instance& buffer, size_t skip_bytes) {
+  if (buffer.length() < skip_bytes) {
+    return POSTGRESQL_FAILURE;
+  }
+  //buffer.drain(skip_bytes);
+  return POSTGRESQL_SUCCESS;
+}
+
+int BufferHelper::readString(Buffer::Instance& buffer, std::string& str) {
+  char end = POSTGRESQL_STR_END;
+  ssize_t index = buffer.search(&end, sizeof(end), 0);
+  if (index == -1) {
+    return POSTGRESQL_FAILURE;
+  }
+  if (static_cast<int>(buffer.length()) < (index + 1)) {
+    return POSTGRESQL_FAILURE;
+  }
+  str.assign(std::string(static_cast<char*>(buffer.linearize(index)), index));
+  str = str.substr(0);
+  buffer.drain(index + 1);
+  return POSTGRESQL_SUCCESS;
+}
+
+int BufferHelper::readStringBySize(Buffer::Instance& buffer, size_t len, std::string& str) {
+  if (buffer.length() < len) {
+    return POSTGRESQL_FAILURE;
+  }
+  str.assign(std::string(static_cast<char*>(buffer.linearize(len)), len));
+  str = str.substr(0);
+  buffer.drain(len);
+  return POSTGRESQL_SUCCESS;
+}
+
+int BufferHelper::peekUint32(Buffer::Instance& buffer, uint32_t& val) {
+  try {
+    val = buffer.peekLEInt<uint32_t>(0);
+    return POSTGRESQL_SUCCESS;
+  } catch (EnvoyException& e) {
+    // buffer underflow
+    return POSTGRESQL_FAILURE;
+  }
+}
+
+} // namespace PostgreSQLProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/postgresql_proxy/postgresql_utils.h
+++ b/source/extensions/filters/network/postgresql_proxy/postgresql_utils.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <cstdint>
+
+#include "envoy/common/platform.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/byte_order.h"
+#include "common/common/logger.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace PostgreSQLProxy {
+
+constexpr int POSTGRESQL_SUCCESS = 0;
+constexpr int POSTGRESQL_FAILURE = -1;
+constexpr char POSTGRESQL_STR_END = '\0';
+
+/**
+ * IO helpers for reading PostgreSQL data from a buffer.
+ */
+class BufferHelper : public Logger::Loggable<Logger::Id::filter> {
+public:
+  static bool endOfBuffer(Buffer::Instance& buffer);
+  static int readUint8(Buffer::Instance& buffer, uint8_t& val);
+  static int readUint16(Buffer::Instance& buffer, uint16_t& val);
+  static int readUint32(Buffer::Instance& buffer, uint32_t& val);
+  static int readBytes(Buffer::Instance& buffer, size_t skip_bytes);
+  static int readString(Buffer::Instance& buffer, std::string& str);
+  static int readStringBySize(Buffer::Instance& buffer, size_t len, std::string& str);
+  static int peekUint32(Buffer::Instance& buffer, uint32_t& val);
+};
+
+} // namespace PostgreSQLProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Add first metrics according discussed on issue #1.

- errors: total number of errors filtered
- sessions: total number of connections
- statements: total number of Statements filtered
- statements_insert: total number of INSERTs filtered
- statements_delete: total number of DELETEs filtered
- statements_update: total number of UPDATEs filtered
- statements_select: total number of SELECTs filtered
- statements_other: total number of other Statements filtered
- transactions: total number of Transactions filtered
- transactions_commit: total number of Committed Transactions filtered
- transactions_rollback: total number of RollbackedTransactions filtered
- warnings: total number of Warnings filtered

Signed-off-by: Fabrízio de Royes Mello <fabrizio@ongres.com>